### PR TITLE
Add workarounds for gfortran memory leak bug 116679

### DIFF
--- a/example/simple_tests.f90
+++ b/example/simple_tests.f90
@@ -17,17 +17,31 @@ contains
   function simple_test_items() result(testitems)
     type(test_item), allocatable :: testitems(:)
 
-    testitems = [&
-        ! Adding a single test not belonging to any test suite
-        test("factorial_0", test_factorial_0),&
+    ! Workaround:gfortran:14.1 (bug 116679)
+    ! Omit array expression to avoid memory leak
+    ! {-
+    ! testitems = [&
+    !     ! Adding a single test not belonging to any test suite
+    !     test("factorial_0", test_factorial_0),&
 
-        ! Packing further tests into a suite in order to introduce more structure
-        ! (e.g. running only tests being part of a given suite)
-        suite("simple", [&
-            test("factorial_1", test_factorial_1),&
-            test("factorial_2", test_factorial_2)&
-        ])&
-    ]
+    !     ! Packing further tests into a suite in order to introduce more structure
+    !     ! (e.g. running only tests being part of a given suite)
+    !     suite("simple", [&
+    !         test("factorial_1", test_factorial_1),&
+    !         test("factorial_2", test_factorial_2)&
+    !     ])&
+    ! ]
+    ! -}{+
+    block
+      type(test_item), allocatable :: itembuffer(:)
+      allocate(testitems(2))
+      testitems(1) = test("factorial_0", test_factorial_0)
+      allocate(itembuffer(2))
+      itembuffer(1) = test("factorial_1", test_factorial_1)
+      itembuffer(2) = test("factorial_2", test_factorial_2)
+      testitems(2) = suite("simple", itembuffer)
+    end block
+    ! +}
 
   end function simple_test_items
 

--- a/src/fortuno/cmdapp.f90
+++ b/src/fortuno/cmdapp.f90
@@ -161,17 +161,29 @@ contains
     !> Argument defintions
     type(argument_def), allocatable :: argdefs(:)
 
-    argdefs = [&
-        & &
-        & argument_def("list", argtypes%bool, shortopt="l", longopt="list",&
-        & helpmsg="show list of tests to run and exit"),&
-        & &
-        & argument_def("tests", argtypes%stringlist,&
+    ! Workaround:gfortran:14.1 (bug 116679)
+    ! Omit array expression to avoid memory leak
+    ! {-
+    ! argdefs = [&
+    !     & &
+    !     & argument_def("list", argtypes%bool, shortopt="l", longopt="list",&
+    !     & helpmsg="show list of tests to run and exit"),&
+    !     & &
+    !     & argument_def("tests", argtypes%stringlist,&
+    !     & helpmsg="list of tests and suites to include or to exclude when prefixed with '~' (e.g.&
+    !     & 'somesuite ~somesuite/avoidedtest' would run all tests except 'avoidedtest' in the test&
+    !     & suite 'somesuite')")&
+    !     & &
+    !     & ]
+    ! -}{+
+    allocate(argdefs(2))
+    argdefs(1) =  argument_def("list", argtypes%bool, shortopt="l", longopt="list",&
+        & helpmsg="show list of tests to run and exit")
+    argdefs(2) = argument_def("tests", argtypes%stringlist,&
         & helpmsg="list of tests and suites to include or to exclude when prefixed with '~' (e.g.&
         & 'somesuite ~somesuite/avoidedtest' would run all tests except 'avoidedtest' in the test&
-        & suite 'somesuite')")&
-        & &
-        & ]
+        & suite 'somesuite')")
+    ! +}
 
   end function default_argument_defs
 

--- a/src/fortuno_serial/serialcase.f90
+++ b/src/fortuno_serial/serialcase.f90
@@ -42,7 +42,17 @@ contains
     procedure(serial_case_proc) :: proc
     type(test_item) :: testitem
 
-    testitem%item = serial_case(name=name, proc=proc)
+    ! Workaround:gfortran:14.1 (bug 116679)
+    ! Omit array expression to avoid memory leak
+    ! {-
+    ! testitem%item = serial_case(name=name, proc=proc)
+    ! -}{+
+    block
+      type(serial_case), allocatable :: item
+      item = serial_case(name=name, proc=proc)
+      call move_alloc(item, testitem%item)
+    end block
+    ! +}
 
   end function serial_case_item
 

--- a/src/fortuno_serial/serialsuite.f90
+++ b/src/fortuno_serial/serialsuite.f90
@@ -24,7 +24,12 @@ contains
     type(test_item), intent(in) :: items(:)
     type(test_item) :: testitem
 
-    testitem%item = serial_suite(name=name, items=items)
+    type(serial_suite), allocatable :: serialsuite
+    allocate(serialsuite)
+    serialsuite%name = name
+    serialsuite%items = items
+    call move_alloc(serialsuite, testitem%item)
+    !testitem%item = serial_suite(name=name, items=items)
 
   end function serial_suite_item
 


### PR DESCRIPTION
Note: only core routines and example/testapp had been fixed so far, other testapps might still leak.

Todo:
* [ ] Fix all testapps
* [ ] Decide on further strategy (waiting for GFortran fix or degrading elegance)

Closes #22 