### PR TITLE
fix: warning: missing terminating " character

### DIFF
--- a/src/fortuno/cmdapp.f90
+++ b/src/fortuno/cmdapp.f90
@@ -170,9 +170,9 @@ contains
     !     & helpmsg="show list of tests to run and exit"),&
     !     & &
     !     & argument_def("tests", argtypes%stringlist,&
-    !     & helpmsg="list of tests and suites to include or to exclude when prefixed with '~' (e.g.&
-    !     & 'somesuite ~somesuite/avoidedtest' would run all tests except 'avoidedtest' in the test&
-    !     & suite 'somesuite')")&
+    !     & helpmsg="list of tests and suites to include or to exclude when prefixed with '~' (e.g. "//&
+    !     & "'somesuite ~somesuite/avoidedtest' would run all tests except 'avoidedtest' in the test "//&
+    !     & "suite 'somesuite')")&
     !     & &
     !     & ]
     ! -}{+
@@ -180,9 +180,9 @@ contains
     argdefs(1) =  argument_def("list", argtypes%bool, shortopt="l", longopt="list",&
         & helpmsg="show list of tests to run and exit")
     argdefs(2) = argument_def("tests", argtypes%stringlist,&
-        & helpmsg="list of tests and suites to include or to exclude when prefixed with '~' (e.g.&
-        & 'somesuite ~somesuite/avoidedtest' would run all tests except 'avoidedtest' in the test&
-        & suite 'somesuite')")
+        & helpmsg="list of tests and suites to include or to exclude when prefixed with '~' (e.g. "//&
+        & "'somesuite ~somesuite/avoidedtest' would run all tests except 'avoidedtest' in the test "//&
+        & "suite 'somesuite')")
     ! +}
 
   end function default_argument_defs


### PR DESCRIPTION
Use string concatenation instead line continuation, otherwise gfortran warns `warning: missing terminating " character`.