### PR TITLE
Add check for skipped status

### DIFF
--- a/src/fortuno/testcontext.f90
+++ b/src/fortuno/testcontext.f90
@@ -47,6 +47,7 @@ module fortuno_testcontext
     procedure :: check_failed => test_context_check_failed
     procedure :: failed => test_context_failed
     procedure :: skip => test_context_skip
+    procedure :: skipped => test_context_skipped
     procedure :: status => test_context_status
     procedure :: pop_failure_info => test_context_pop_failure_info
     procedure :: push_scope_ptr => test_context_push_scope_ptr
@@ -232,6 +233,20 @@ contains
     if (this%status_ == teststatus%succeeded) this%status_ = teststatus%skipped
 
   end subroutine test_context_skip
+
+
+  !> Whether the test had been requested to be skip
+  pure function test_context_skipped(this) result(skipped)
+
+    !> Instance
+    class(test_context), intent(in) :: this
+
+    !> Skip status
+    logical :: skipped
+
+    skipped = this%status_ == teststatus%skipped
+
+  end function test_context_skipped
 
 
   !> Pops the failure info from the context

--- a/src/fortuno_mpi.f90
+++ b/src/fortuno_mpi.f90
@@ -8,7 +8,7 @@ module fortuno_mpi
   use fortuno_mpi_mpicmdapp, only : mpi_cmd_app, execute_mpi_cmd_app
   use fortuno_mpi_mpicontext, only : mpi_context
   use fortuno_mpi_mpiglobalctx, only : global_comm, global_comm_id, mpi_check, mpi_check_failed,&
-      & mpi_failed, mpi_skip, mpi_scope_pointers, num_ranks, this_rank
+      & mpi_failed, mpi_skip, mpi_skipped, mpi_scope_pointers, num_ranks, this_rank
   use fortuno_mpi_mpicase, only : mpi_case, mpi_case_item
   use fortuno_mpi_mpisuite, only : mpi_suite, mpi_suite_item
   implicit none

--- a/src/fortuno_mpi/mpiglobalctx.f90
+++ b/src/fortuno_mpi/mpiglobalctx.f90
@@ -12,7 +12,7 @@ module fortuno_mpi_mpiglobalctx
   private
   public :: mpiglobalctx
   public :: set_mpi_global_context
-  public :: mpi_check, mpi_check_failed, mpi_failed, mpi_skip
+  public :: mpi_check, mpi_check_failed, mpi_failed, mpi_skip, mpi_skipped
   public :: mpi_scope_pointers
   public :: global_comm, global_comm_id
   public :: num_ranks, this_rank
@@ -108,11 +108,25 @@ contains
 
 
   !> Mark current test/context as skipped
+  !!
+  !! Note: All processes must call skip() synchronously to ensure consistent behavior
+  !!
   subroutine mpi_skip()
 
     call mpiglobalctx%skip()
 
   end subroutine mpi_skip
+
+
+  !> Whether the test had been marked as skipped
+  function mpi_skipped() result(skipped)
+
+    !> Skip status
+    logical :: skipped
+
+    skipped = mpiglobalctx%skipped()
+
+  end function mpi_skipped
 
 
   !> Returns the enclosing suite pointers

--- a/src/fortuno_serial.f90
+++ b/src/fortuno_serial.f90
@@ -9,7 +9,7 @@ module fortuno_serial
   use fortuno_serial_serialcmdapp, only : execute_serial_cmd_app, init_serial_cmd_app,&
       & serial_cmd_app
   use fortuno_serial_serialglobalctx, only : serial_check, serial_check_failed, serial_failed,&
-      & serial_scope_pointers, serial_skip, serial_store_state
+      & serial_scope_pointers, serial_skip, serial_skipped, serial_store_state
   use fortuno_serial_serialcase, only : serial_case, serial_case_item
   use fortuno_serial_serialsuite, only : serial_suite, serial_suite_item
   implicit none

--- a/src/fortuno_serial/serialglobalctx.f90
+++ b/src/fortuno_serial/serialglobalctx.f90
@@ -11,7 +11,9 @@ module fortuno_serial_serialglobalctx
   private
   public :: serialglobalctx
   public :: set_serial_global_context
-  public :: serial_check, serial_check_failed, serial_failed, serial_skip, serial_store_state
+  public :: serial_check, serial_check_failed, serial_failed
+  public :: serial_skip, serial_skipped
+  public :: serial_store_state
   public :: serial_scope_pointers
 
 
@@ -109,6 +111,17 @@ contains
     call serialglobalctx%skip()
 
   end subroutine serial_skip
+
+
+  !> Whether test had been marked as skipped
+  function serial_skipped() result(skipped)
+
+    !> Skip status
+    logical :: skipped
+
+    skipped = serialglobalctx%skipped()
+
+  end function serial_skipped
 
 
   !> Returns the enclosing suite pointers


### PR DESCRIPTION
Instead of
```
if (COND) then
  call skip()
  return
end if
```
one can now write
```
if (COND) call skip()
if (skipped()) return
```