### PR TITLE
Reduce warnings & Initialise MPI with MPI_Init_thread

### DIFF
--- a/example/serial-fpp/test_fixtured_suite_fpp.F90
+++ b/example/serial-fpp/test_fixtured_suite_fpp.F90
@@ -129,7 +129,7 @@ contains
     integer :: nn
 
     nn = -1
-    scopeptrs = scope_pointers()
+    allocate(scopeptrs, source=scope_pointers())
     ! scopeptrs(1): current scope - random_test_case instance
     ! scopeptrs(2): first enclosing scope - random_test_suite instance
     if (size(scopeptrs) < 2)&

--- a/example/serial/test_fixtured_suite.f90
+++ b/example/serial/test_fixtured_suite.f90
@@ -127,7 +127,7 @@ contains
     integer :: nn
 
     nn = -1
-    scopeptrs = scope_pointers()
+    allocate(scopeptrs, source=scope_pointers())
     ! scopeptrs(1): current scope - random_test_case instance
     ! scopeptrs(2): first enclosing scope - random_test_suite instance
     if (size(scopeptrs) < 2)&

--- a/example/serial/test_simple.f90
+++ b/example/serial/test_simple.f90
@@ -68,7 +68,7 @@ contains
 
     real(r32), allocatable :: yvals(:,:)
 
-    yvals = cotanvals
+    allocate(yvals, source=cotanvals)
     ! We add a "bug" for the 3rd element to demonstrate the failure
     yvals(1, 2) = yvals(1, 2) + 0.1_r32
 

--- a/src/fortuno/checkers/int_template.inc
+++ b/src/fortuno/checkers/int_template.inc
@@ -44,7 +44,8 @@
           & checkresult)
       return
     end if
-    match = value1 == value2
+    allocate(match(size(value1, dim=1)))
+    match(:) = value1 == value2
     mismatchloc = findloc(match, .false., kind=i64)
     if (all(mismatchloc /= 0)) then
       call add_value_mismatch_details("mismatching integer values",&
@@ -77,7 +78,8 @@
           & checkresult)
       return
     end if
-    match = value1 == value2
+    allocate(match(size(value1, dim=1), size(value1, dim=2)))
+    match(:,:) = value1 == value2
     mismatchloc = findloc(match, .false., kind=i64)
     if (all(mismatchloc /= 0)) then
       call add_value_mismatch_details("mismatching integer values",&
@@ -106,7 +108,8 @@
     logical, allocatable :: match(:)
     integer(i64) :: mismatchloc(1)
 
-    match = value1 == value2
+    allocate(match(size(value1, dim=1)))
+    match(:) = value1 == value2
     mismatchloc = findloc(match, .false., kind=i64)
     if (all(mismatchloc /= 0)) then
       call add_value_mismatch_details("mismatching integer values",&
@@ -134,7 +137,8 @@
     logical, allocatable :: match(:)
     integer(i64) :: mismatchloc(1)
 
-    match = value1 == value2
+    allocate(match(size(value2, dim=1)))
+    match(:) = value1 == value2
     mismatchloc = findloc(match, .false., kind=i64)
     if (all(mismatchloc /= 0)) then
       call add_value_mismatch_details("mismatching integer values",&
@@ -147,7 +151,7 @@
   end function all_equal_r0_r1
 
 
-  !> Checks whether two integer rank 1 arrays are equal.
+  !> Checks whether a scalar integer is equal to an integer rank 2 array.
   function all_equal_r2_r0(value1, value2) result(checkresult)
 
     !> First value to check
@@ -162,7 +166,8 @@
     logical, allocatable :: match(:,:)
     integer(i64) :: mismatchloc(2)
 
-    match = value1 == value2
+    allocate(match(size(value1, dim=1), size(value1, dim=2)))
+    match(:,:) = value1 == value2
     mismatchloc = findloc(match, .false., kind=i64)
     if (all(mismatchloc /= 0)) then
       call add_value_mismatch_details("mismatching integer values",&
@@ -175,7 +180,7 @@
   end function all_equal_r2_r0
 
 
-  !> Checks whether two integer rank 1 arrays are equal.
+  !> Checks whether a scalar integer is equal to an integer rank 2 array.
   function all_equal_r0_r2(value1, value2) result(checkresult)
 
     !> First value to check
@@ -190,7 +195,8 @@
     logical, allocatable :: match(:,:)
     integer(i64) :: mismatchloc(2)
 
-    match = value1 == value2
+    allocate(match(size(value2, dim=1), size(value2, dim=2)))
+    match(:,:) = value1 == value2
     mismatchloc = findloc(match, .false., kind=i64)
     if (all(mismatchloc /= 0)) then
       call add_value_mismatch_details("mismatching integer values",&

--- a/src/fortuno/checkers/real_template.inc
+++ b/src/fortuno/checkers/real_template.inc
@@ -56,7 +56,8 @@
           & checkresult)
       return
     end if
-    match = is_close_elem(value1, value2, atol=atol, rtol=rtol)
+    allocate(match(size(value1, dim=1)))
+    match(:) = is_close_elem(value1, value2, atol=atol, rtol=rtol)
     mismatchloc(:) = findloc(match, .false., kind=i64)
     if (all(mismatchloc /= 0)) then
       call add_value_mismatch_details("real values differing beyond tolerance",&
@@ -95,7 +96,8 @@
           & checkresult)
       return
     end if
-    match = is_close_elem(value1, value2, atol=atol, rtol=rtol)
+    allocate(match(size(value1, dim=1), size(value1, dim=2)))
+    match(:,:) = is_close_elem(value1, value2, atol=atol, rtol=rtol)
     mismatchloc(:) = findloc(match, .false., kind=i64)
     if (all(mismatchloc /= 0)) then
       call add_value_mismatch_details("real values differing beyond tolerance",&
@@ -130,7 +132,8 @@
     logical, allocatable :: match(:)
     integer(i64) :: mismatchloc(1)
 
-    match = is_close_elem(value1, value2, atol=atol, rtol=rtol)
+    allocate(match(size(value1, dim=1)))
+    match(:) = is_close_elem(value1, value2, atol=atol, rtol=rtol)
     mismatchloc(:) = findloc(match, .false., kind=i64)
     if (all(mismatchloc /= 0)) then
       call add_value_mismatch_details("real values differing beyond tolerance",&
@@ -164,7 +167,8 @@
     logical, allocatable :: match(:)
     integer(i64) :: mismatchloc(1)
 
-    match = is_close_elem(value1, value2, atol=atol, rtol=rtol)
+    allocate(match(size(value2, dim=1)))
+    match(:) = is_close_elem(value1, value2, atol=atol, rtol=rtol)
     mismatchloc(:) = findloc(match, .false., kind=i64)
     if (all(mismatchloc /= 0)) then
       call add_value_mismatch_details("real values differing beyond tolerance",&
@@ -198,7 +202,8 @@
     logical, allocatable :: match(:,:)
     integer(i64) :: mismatchloc(2)
 
-    match = is_close_elem(value1, value2, atol=atol, rtol=rtol)
+    allocate(match(size(value1, dim=1), size(value1, dim=2)))
+    match(:,:) = is_close_elem(value1, value2, atol=atol, rtol=rtol)
     mismatchloc(:) = findloc(match, .false., kind=i64)
     if (all(mismatchloc /= 0)) then
       call add_value_mismatch_details("real values differing beyond tolerance",&
@@ -233,7 +238,8 @@
     logical, allocatable :: match(:,:)
     integer(i64) :: mismatchloc(2)
 
-    match = is_close_elem(value1, value2, atol=atol, rtol=rtol)
+    allocate(match(size(value2, dim=1), size(value2, dim=2)))
+    match(:,:) = is_close_elem(value1, value2, atol=atol, rtol=rtol)
     mismatchloc(:) = findloc(match, .false., kind=i64)
     if (all(mismatchloc /= 0)) then
       call add_value_mismatch_details("real values differing beyond tolerance",&

--- a/src/fortuno/cmdapp.f90
+++ b/src/fortuno/cmdapp.f90
@@ -170,9 +170,9 @@ contains
     !     & helpmsg="show list of tests to run and exit"),&
     !     & &
     !     & argument_def("tests", argtypes%stringlist,&
-    !     & helpmsg="list of tests and suites to include or to exclude when prefixed with '~' (e.g.&
-    !     & 'somesuite ~somesuite/avoidedtest' would run all tests except 'avoidedtest' in the test&
-    !     & suite 'somesuite')")&
+    !     & helpmsg="list of tests and suites to include or to exclude when prefixed with '~' (e.g. " //&
+    !     & "'somesuite ~somesuite/avoidedtest' would run all tests except 'avoidedtest' in the test " //&
+    !     & "suite 'somesuite')")&
     !     & &
     !     & ]
     ! -}{+
@@ -180,9 +180,9 @@ contains
     argdefs(1) =  argument_def("list", argtypes%bool, shortopt="l", longopt="list",&
         & helpmsg="show list of tests to run and exit")
     argdefs(2) = argument_def("tests", argtypes%stringlist,&
-        & helpmsg="list of tests and suites to include or to exclude when prefixed with '~' (e.g.&
-        & 'somesuite ~somesuite/avoidedtest' would run all tests except 'avoidedtest' in the test&
-        & suite 'somesuite')")
+        & helpmsg="list of tests and suites to include or to exclude when prefixed with '~' (e.g. " // &
+        & "'somesuite ~somesuite/avoidedtest' would run all tests except 'avoidedtest' in the test " // &
+        & "suite 'somesuite')")
     ! +}
 
   end function default_argument_defs

--- a/src/fortuno/consolelogger.f90
+++ b/src/fortuno/consolelogger.f90
@@ -208,12 +208,9 @@ contains
 
     maxitems = maxval([sum(driveresult%suitestats, dim=1), sum(driveresult%teststats)])
     numfieldwidth = len(str(maxitems))
-    call log_summary_("# Suite set-ups", driveresult%suiteresults(1, :),&
-        & driveresult%suitestats(:, 1), numfieldwidth)
-    call log_summary_("# Suite tear-downs", driveresult%suiteresults(2, :),&
-        & driveresult%suitestats(:, 2), numfieldwidth)
-    call log_summary_("# Test runs", driveresult%testresults, driveresult%teststats,&
-        & numfieldwidth)
+    call log_summary_("# Suite set-ups", driveresult%suitestats(:, 1), numfieldwidth)
+    call log_summary_("# Suite tear-downs", driveresult%suitestats(:, 2), numfieldwidth)
+    call log_summary_("# Test runs", driveresult%teststats, numfieldwidth)
     call log_success_(driveresult%successful)
 
   end subroutine console_logger_log_drive_result
@@ -366,9 +363,8 @@ contains
 
 
   !! Logs test summary
-  subroutine log_summary_(header, testresults, teststats, numfieldwidth)
+  subroutine log_summary_(header, teststats, numfieldwidth)
     character(*), intent(in) :: header
-    type(test_result), intent(in) :: testresults(:)
     integer, intent(in) :: teststats(:)
     integer, intent(in) :: numfieldwidth
 


### PR DESCRIPTION
This MR does two separate things:

* Several commits, removing several gfortran compiler warnings
* One commit replacing `MPI_INIT` with `MPI_Init_thread`, where I request the maximum threading support

W.r.t. compiler warnings, most of the changes silence false positives resulting from implicit LHS allocation. In these cases, I've just added explicit `allocate` statements. A couple others are from unused arguments. In one instance, I've removed an argument (see the logger) and in the other I'm assigned a dummy attribute.

W.r.t. replacing `MPI_INIT` with `MPI_Init_thread`. There's no obvious reason (to me) not to do this, and if a consumer/client code initialises with anything other than `MPI_THREAD_SINGLE`, this is required. As such, I initialise with `MPI_THREAD_MULTIPLE`, which should maximise support.

It is still the client code's responsibility to check what's actually [provided](https://rookiehpc.org/mpi/docs/mpi_thread_serialized/index.html) by the MPI library, and handle appropriately:

```fortran
    call MPI_Query_thread(provided)
    if (provided < required) then
      call MPI_Comm_rank(MPI_COMM_WORLD, rank)
      if (rank == 0) write(*, '(a)') 'MPI library threading support is less than required by <MY CODE>'
      call MPI_Abort(MPI_COMM_WORLD, 1, ierr)
    end if
``





 